### PR TITLE
Fix typo 'ref' to 'href'

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <script>
   if (window.location.protocol === 'http:') {
       // redirect to https
-      window.location = 'https' + window.location.ref.slice(4);
+      window.location = 'https' + window.location.href.slice(4);
   }
 </script>
 <script>


### PR DESCRIPTION
Redirect from http to https was broken because `href` key of `window.location.href` was misspelled as `ref`. This PR simply changes the key to `href`.

@rgbkrk @minrk